### PR TITLE
Moved caption under main SVG.

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,10 +189,10 @@ aFutureWithoutCompilers
       <tr>
         <td valign="top" class="leftCol">
           <p onclick="changeImage(event)" id="slideHolder"></p>
-          <p id="caption"></p>
         </td>
         <td valign="center" class="rightCol" id="heroHolder">
           <img id="heroImage" src="demos/helloWorld3D.svg" title="Code you could hold in your hand" />
+          <p id="caption"></p>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
Addressing #14 - The caption has been moved from under the links to under the SVG.

This looked a bit too simple - please let me know if I am overlooking something.

Hope it helped!