### PR TITLE
Left-align and fix height for caption

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,8 @@
       }
       #caption {
         padding-right: 10px;
+        text-align: left;
+        height: 5rem;
       }
     </style>
     <title>Tree Notation</title>


### PR DESCRIPTION
A second pull request to address #14 — now the caption is left-aligned and has a height of `5rem` so that the content below does not jump around. The value may need to be changed if the descriptions become longer.

I hope this is the intended look!